### PR TITLE
Consolidated data loading and rendering logic in the census pages

### DIFF
--- a/Home.py
+++ b/Home.py
@@ -11,7 +11,7 @@ streamlit run Home.py
 
 # Necessary imports
 import streamlit as st
-from app_utils import get_user_files, process_uploaded_files
+from app_utils.file_handling import get_user_files, process_uploaded_files
 
 
 def main():

--- a/app_utils/census.py
+++ b/app_utils/census.py
@@ -7,6 +7,10 @@ Census Utility Functions
 
 import pandas as pd
 
+import requests
+import pyogrio  
+import io
+
 
 def split_name_col(census_gdf):
     """
@@ -122,6 +126,15 @@ def get_geography_title(county, jurisdiction):
         title_geo = f"{jurisdiction}"
     
     return title_geo
+
+def load_census_data(url, is_geospatial=False):
+    ## gen. func to get the census data and split it from the url and file type (currently binary)
+    if is_geospatial:
+        df = pyogrio.read_dataframe(url)
+    else:
+        response = requests.get(url, verify=True)
+        df = pd.read_csv(io.StringIO(response.text))
+    return split_name_col(df)
 
 
 def calculate_delta_values(filtered_gdf_2023, baseline, filtered_gdf_2013, housing_gdf):

--- a/app_utils/st_sections.py
+++ b/app_utils/st_sections.py
@@ -1,0 +1,77 @@
+import streamlit as st
+from app_utils.color import render_colorbar, map_outlier_yellow, jenks_color_map, get_colornorm_stats, TopHoldNorm
+from  matplotlib import colormaps
+import matplotlib.cm as cm
+import matplotlib.colors as colors
+import pydeck as pdk
+from streamlit_rendering import filter_dataframe
+
+
+def mapping_tab(data): 
+    st.subheader("Mapping")
+    
+    # Project meaningful columns to lat/long
+    filtered_2023 = filter_dataframe(data, filter_columns=["Category", "Subcategory", "Variable", "Measure"])
+    filtered_2023 = filtered_2023.to_crs(epsg=4326)
+
+    # Normalize the housing variable for monochromatic chloropleth coloring
+    vmin, vmax, cutoff  = get_colornorm_stats(filtered_2023, 5)
+    cmap = colormaps["Reds"]
+    
+    norm = colors.Normalize(vmin=vmin, vmax=vmax)
+    cmap = cm.get_cmap("Reds")
+
+    style = st.radio("Outlier Handling:", options=["Jenk's Natural Breaks", "Yellow", "Holdout"], horizontal=True)
+
+    if style == "Holdout":
+        # Option One:  Outliers get the top 10% of the norm (same color, just gradation shifts)
+        norm = TopHoldNorm(vmin=vmin, vmax=vmax, cutoff=cutoff, outlier_fraction=0.1)
+        # Convert colors to [R, G, B, A] values
+        filtered_2023["fill_color"] = filtered_2023['Value'].apply(
+            lambda x: [int(c * 255) for c in cmap(norm(x))[:3]] + [180])
+        render_colorbar(cmap=cmap, norm=norm, vmin=vmin, vmax=vmax, cutoff=cutoff, style=style)
+    
+    elif style == "Yellow":
+        # Option Two: Outliers get a separate color (yellow)
+        norm = colors.Normalize(vmin=vmin, vmax=cutoff, clip=False)
+        filtered_2023["fill_color"] = filtered_2023["Value"].apply(
+            lambda x: map_outlier_yellow(x, cmap, norm, cutoff))
+        render_colorbar(cmap=cmap, norm=norm, vmin=vmin, vmax=vmax, cutoff=cutoff, style=style)
+    
+    elif style == "Jenk's Natural Breaks":
+        # Option Two: Jenk's Natural Breaks Algorithm
+        # Using a slider, adjust the number of "groups" in the data
+        col1, _, _ = st.columns(3)
+        n_classes = col1.slider(label="Adjust the level of detail", value=10, min_value=5, max_value=15)
+        # Define the Jenk's colormap and apply it to the dataframe
+        jenks_cmap_dict = jenks_color_map(filtered_2023, n_classes, "Reds")
+        filtered_2023['fill_color'] = filtered_2023['color_groups'].astype(str).map(jenks_cmap_dict)
+        # Fill null values with a transparent color
+        filtered_2023['fill_color'] = filtered_2023['fill_color'].fillna("(0, 0, 0, 0)")
+
+    # Convert the geometry column to GeoJSON coordinates
+    filtered_2023["coordinates"] = filtered_2023.geometry.apply(
+        lambda geom: geom.__geo_interface__["coordinates"]) 
+
+    # Chloropleth map layer
+    polygon_layer = pdk.Layer(
+        "PolygonLayer",
+        data=filtered_2023,
+        get_polygon="coordinates[0]",
+        get_fill_color="fill_color",
+        pickable=True,
+        auto_highlight=True)
+
+    # Set the map center and zoom settings
+    view_state = pdk.ViewState(latitude=44.26, longitude=-72.57, min_zoom=6.5, zoom=7)
+
+    # Display the map to the page
+    st.pydeck_chart(pdk.Deck(
+        layers=[polygon_layer],
+        initial_view_state=view_state,
+        map_style="https://basemaps.cartocdn.com/gl/positron-gl-style/style.json",
+        tooltip={"text": "{Jurisdiction}: {Value}"}), height=550)
+    
+
+def compare_tab(data):
+    st.radio("Hmm", ["help", "please"])

--- a/pages/6_Housing.py
+++ b/pages/6_Housing.py
@@ -10,94 +10,42 @@ Housing Page (Census)
 # Necessary imports
 import streamlit as st
 import pandas as pd
-import matplotlib.cm as cm
-from  matplotlib import colormaps
-import matplotlib.colors as colors
-import pydeck as pdk
-import pyogrio
 import requests
 import io
-from app_utils.census import split_name_col, rename_and_merge_census_cols
+from app_utils.census import rename_and_merge_census_cols, load_census_data
 from app_utils.housing import housing_pop_plot, housing_snapshot
-from app_utils.color import render_colorbar, map_outlier_yellow, jenks_color_map, get_colornorm_stats, TopHoldNorm
-from streamlit_rendering import filter_dataframe
-
-
-@st.cache_data()
-def load_data():
-    # TODO: consider more elaborate caching in session_state vars, etc. 
-    # TODO: consider packaging the data directly into the repository.
-    st.write("Load Data Function")
-
-
-@st.cache_data
-def load_2023_housing():
-    url_2023 = 'https://raw.githubusercontent.com/iansargent/Data-Exploration-Tool-in-Python/main/Data/Census/VT_HOUSING_ALL.fgb'
-    housing_gdf_2023 = pyogrio.read_dataframe(url_2023)
-    housing_gdf_2023 = split_name_col(housing_gdf_2023)
-    
-    return housing_gdf_2023
-
-
-@st.cache_data
-def load_2013_housing():
-    url_2013 = 'https://raw.githubusercontent.com/iansargent/Data-Exploration-Tool-in-Python/main/Data/Census/VT_HOUSING_ALL_2013.fgb'
-    housing_gdf_2013 = pyogrio.read_dataframe(url_2013)
-    housing_gdf_2013 = split_name_col(housing_gdf_2013)
-    
-    return housing_gdf_2013
-
-
-@st.cache_data
-def load_med_value_by_year():
-    import requests
-
-    med_value_url = "https://raw.githubusercontent.com/iansargent/Data-Exploration-Tool-in-Python/main/Data/Census/med_home_value_by_year.csv"
-    response = requests.get(med_value_url, verify=True) # disables SSL verification
-    med_value_df = pd.read_csv(io.StringIO(response.text))     
-    med_value_df = split_name_col(med_value_df)
-    
-    return med_value_df
-
-
-@st.cache_data
-def load_med_smoc_by_year():
-    import requests
-
-    med_smoc_url = "https://raw.githubusercontent.com/iansargent/Data-Exploration-Tool-in-Python/main/Data/Census/med_smoc_by_year.csv"
-    response = requests.get(med_smoc_url, verify=True) # disables SSL verification
-    med_smoc_df = pd.read_csv(io.StringIO(response.text))
-
-    med_smoc_df = split_name_col(med_smoc_df)     
-    
-    return med_smoc_df
+from app_utils.st_sections import mapping_tab, compare_tab
 
 
 @st.cache_data
 def census_housing():
-    # Read the Census Housing Datasets (Name column is split here as well!)
-    housing_gdf_2023 = load_2023_housing()
-    housing_gdf_2013 = load_2013_housing()
-    med_val_df = load_med_value_by_year()
+    housing_gdf_2023 = load_census_data(
+        "https://raw.githubusercontent.com/iansargent/Data-Exploration-Tool-in-Python/main/Data/Census/VT_HOUSING_ALL.fgb",
+        is_geospatial=True
+    )
+    
+    housing_gdf_2013 = load_census_data(
+        "https://raw.githubusercontent.com/iansargent/Data-Exploration-Tool-in-Python/main/Data/Census/VT_HOUSING_ALL_2013.fgb",
+        is_geospatial=True
+    )
+    
+    med_value_df = load_census_data(
+    "https://raw.githubusercontent.com/iansargent/Data-Exploration-Tool-in-Python/main/Data/Census/med_home_value_by_year.csv")
+    
+    med_smoc_df = load_census_data(
+    "https://raw.githubusercontent.com/iansargent/Data-Exploration-Tool-in-Python/main/Data/Census/med_smoc_by_year.csv")
 
-    # Split the "name" column into separate "County" and "Jurisdiction" columns, then rename the cols
     tidy_2023 = rename_and_merge_census_cols(housing_gdf_2023)
-
-    return housing_gdf_2023, housing_gdf_2013, med_val_df, tidy_2023
+    return housing_gdf_2023, housing_gdf_2013, med_value_df, med_smoc_df, tidy_2023
 
 
 def census_housing_page():
-    # Page title
+    # Page title and tabs
     st.header("Housing", divider="grey")
+    mapping, snapshot, compare = st.tabs(tabs=["Mapping", "Snapshot", "Compare"])
 
-    mapping, snapshot = st.tabs(tabs=["Mapping", "Snapshot"])
-
-    #TODO: Working on a load_data function above
-    # housing_gdf_2023, housing_gdf_2013, med_val_df, tidy_2023 = load_data()
-    
     # Define and load the datasets
-    housing_gdf_2023, housing_gdf_2013, med_val_df, tidy_2023 = census_housing()
-    med_smoc_df = load_med_smoc_by_year()
+    housing_gdf_2023, housing_gdf_2013, med_val_df, med_smoc_df, tidy_2023 = census_housing()
     
     # Compute statewide average median home value by year
     statewide_avg_val_df = (med_val_df.groupby("year", as_index=False)["estimate"].mean())
@@ -105,71 +53,8 @@ def census_housing_page():
 
     ##  The map section ## 
     with mapping:
-        st.subheader("Mapping")
-        
-        # Project meaningful columns to lat/long
-        filtered_2023 = filter_dataframe(tidy_2023, filter_columns=["Category", "Subcategory", "Variable", "Measure"])
-        filtered_2023 = filtered_2023.to_crs(epsg=4326)
-
-        # Normalize the housing variable for monochromatic chloropleth coloring
-        vmin, vmax, cutoff  = get_colornorm_stats(filtered_2023, 5)
-        cmap = colormaps["Reds"]
-        
-        norm = colors.Normalize(vmin=vmin, vmax=vmax)
-        cmap = cm.get_cmap("Reds")
-
-        style = st.radio("Outlier Handling:", options=["Jenk's Natural Breaks", "Yellow", "Holdout"], horizontal=True)
-
-        if style == "Holdout":
-            # Option One:  Outliers get the top 10% of the norm (same color, just gradation shifts)
-            norm = TopHoldNorm(vmin=vmin, vmax=vmax, cutoff=cutoff, outlier_fraction=0.1)
-            # Convert colors to [R, G, B, A] values
-            filtered_2023["fill_color"] = filtered_2023['Value'].apply(
-                lambda x: [int(c * 255) for c in cmap(norm(x))[:3]] + [180])
-            render_colorbar(cmap=cmap, norm=norm, vmin=vmin, vmax=vmax, cutoff=cutoff, style=style)
-        
-        elif style == "Yellow":
-            # Option Two: Outliers get a separate color (yellow)
-            norm = colors.Normalize(vmin=vmin, vmax=cutoff, clip=False)
-            filtered_2023["fill_color"] = filtered_2023["Value"].apply(
-                lambda x: map_outlier_yellow(x, cmap, norm, cutoff))
-            render_colorbar(cmap=cmap, norm=norm, vmin=vmin, vmax=vmax, cutoff=cutoff, style=style)
-        
-        elif style == "Jenk's Natural Breaks":
-            # Option Two: Jenk's Natural Breaks Algorithm
-            # Using a slider, adjust the number of "groups" in the data
-            col1, _, _ = st.columns(3)
-            n_classes = col1.slider(label="Adjust the level of detail", value=10, min_value=5, max_value=15)
-            # Define the Jenk's colormap and apply it to the dataframe
-            jenks_cmap_dict = jenks_color_map(filtered_2023, n_classes, "Reds")
-            filtered_2023['fill_color'] = filtered_2023['color_groups'].astype(str).map(jenks_cmap_dict)
-            # Fill null values with a transparent color
-            filtered_2023['fill_color'] = filtered_2023['fill_color'].fillna("(0, 0, 0, 0)")
-
-        # Convert the geometry column to GeoJSON coordinates
-        filtered_2023["coordinates"] = filtered_2023.geometry.apply(
-            lambda geom: geom.__geo_interface__["coordinates"]) 
-
-        # Chloropleth map layer
-        polygon_layer = pdk.Layer(
-            "PolygonLayer",
-            data=filtered_2023,
-            get_polygon="coordinates[0]",
-            get_fill_color="fill_color",
-            pickable=True,
-            auto_highlight=True)
-
-        # Set the map center and zoom settings
-        view_state = pdk.ViewState(latitude=44.26, longitude=-72.57, min_zoom=6.5, zoom=7)
-
-        # Display the map to the page
-        st.pydeck_chart(pdk.Deck(
-            layers=[polygon_layer],
-            initial_view_state=view_state,
-            map_style="https://basemaps.cartocdn.com/gl/positron-gl-style/style.json",
-            tooltip={"text": "{Jurisdiction}: {Value}"}), height=550)
-
-
+        mapping_tab(tidy_2023)
+    
     # Housing Snapshot
     with snapshot:
         st.subheader("Housing Snapshot")
@@ -232,6 +117,9 @@ def census_housing_page():
                         statewide_avg_val_df, statewide_avg_smoc_df, compare_to)
 
 
+    with compare:
+        compare_tab(data=tidy_2023)
+        
 def show_housing():
     # Display the page
     census_housing_page()

--- a/pages/8_Demographics.py
+++ b/pages/8_Demographics.py
@@ -8,80 +8,34 @@ Demographics Page (Census)
 
 # Necessary imports
 import streamlit as st
-import pydeck as pdk
-import pyogrio
-from streamlit_rendering import filter_dataframe
-from app_utils.census import split_name_col, rename_and_merge_census_cols
-from app_utils.color import jenks_color_map
+from app_utils.census import rename_and_merge_census_cols, load_census_data
+from app_utils.st_sections import mapping_tab, compare_tab
 
 
 @st.cache_data
 def load_2023_demographics():
-    url_2023 = 'https://raw.githubusercontent.com/iansargent/Data-Exploration-Tool-in-Python/main/Data/Census/VT_DEMOGRAPHIC_ALL.fgb'
-    demographics_gdf_2023 = pyogrio.read_dataframe(url_2023)
-    demographics_gdf_2023 = split_name_col(demographics_gdf_2023)
-    
-    return demographics_gdf_2023
+    return load_census_data(
+        "https://raw.githubusercontent.com/iansargent/Data-Exploration-Tool-in-Python/main/Data/Census/VT_DEMOGRAPHIC_ALL.fgb",
+        is_geospatial=True
+        )
 
 def render_demographics():
     # Page header
     st.header("Demographics", divider="grey")   
-    mapping, snapshot = st.tabs(tabs=["Mapping", "Snapshot"])
+    mapping, snapshot, compare = st.tabs(tabs=["Mapping", "Snapshot", "Compare"])
 
     demographics_gdf_2023 = load_2023_demographics()
     tidy_2023 = rename_and_merge_census_cols(demographics_gdf_2023)
 
     with mapping:
-        st.subheader("Mapping")
-        
-        # Select the combination of vars we're interested in
-        filtered_2023 = filter_dataframe(tidy_2023, filter_columns=["Category", "Subcategory", "Variable", "Measure"])
-        # Project geometry to latitude and longitude coordinates
-        filtered_2023 = filtered_2023.to_crs(epsg=4326)
-
-        col1, _, _ = st.columns(3)
-        n_classes = col1.slider(label="Adjust the level of detail", value=10, min_value=5, max_value=15)
-        # Define the Jenk's colormap and apply it to the dataframe
-        jenks_cmap_dict = jenks_color_map(filtered_2023, n_classes, "Blues")
-        filtered_2023['fill_color'] = filtered_2023['color_groups'].astype(str).map(jenks_cmap_dict)
-        # Fill null values with a transparent color
-        filtered_2023['fill_color'] = filtered_2023['fill_color'].fillna("(0, 0, 0, 0)")
-
-        # Convert the geometry column to GeoJSON coordinates
-        filtered_2023["coordinates"] = filtered_2023.geometry.apply(
-            lambda geom: geom.__geo_interface__["coordinates"])
-            
-        # Chloropleth map layer
-        polygon_layer = pdk.Layer(
-            "PolygonLayer",
-            data=filtered_2023,
-            get_polygon="coordinates[0]",
-            get_fill_color="fill_color",
-            pickable=True,
-            auto_highlight=True,
-        )
-
-        # Set the map center and zoom level
-        view_state = pdk.ViewState(latitude=44.26, longitude=-72.57, min_zoom=6.5, zoom=7)
-
-        # Display the map to the page
-        st.pydeck_chart(pdk.Deck(
-            layers=[polygon_layer],
-            initial_view_state=view_state,
-            map_style="https://basemaps.cartocdn.com/gl/positron-gl-style/style.json",
-            tooltip={"text": "{Jurisdiction}: {Value}"}), height=550)
-        
-        tidy_2023
-        filtered_2023
+        mapping_tab(data=tidy_2023)
 
     ## Census Snapshot section (Housing) ##
     with snapshot:
         st.subheader("Demographic Snapshot")
-            
-def show_demographics():
-    # Display the page
-    render_demographics()
 
+    with compare:
+        compare_tab(data=tidy_2023)           
 
 if __name__ == "__main__":
-    show_demographics()
+    render_demographics()

--- a/pages/9_Social.py
+++ b/pages/9_Social.py
@@ -8,73 +8,35 @@ Social Page (Census)
 
 # Necessary imports
 import streamlit as st
-import pydeck as pdk
-import pyogrio
-from streamlit_rendering import filter_dataframe
-from app_utils.census import split_name_col, rename_and_merge_census_cols
-from app_utils.color import jenks_color_map
-
+from app_utils.census import load_census_data, rename_and_merge_census_cols
+from app_utils.st_sections import mapping_tab, compare_tab
 
 @st.cache_data
 def load_2023_social():
-    url_2023 = 'https://raw.githubusercontent.com/iansargent/Data-Exploration-Tool-in-Python/main/Data/Census/VT_SOCIAL_ALL.fgb'
-    social_gdf_2023 = pyogrio.read_dataframe(url_2023)
-    social_gdf_2023 = split_name_col(social_gdf_2023)
-    
-    return social_gdf_2023
+    return load_census_data(
+        'https://raw.githubusercontent.com/iansargent/Data-Exploration-Tool-in-Python/main/Data/Census/VT_SOCIAL_ALL.fgb',
+        is_geospatial=True)
 
 
 def render_social():
     # Page header
     st.header("Social", divider="grey")
-    mapping, snapshot = st.tabs(tabs=["Mapping", "Snapshot"])
+    mapping, snapshot, compare = st.tabs(tabs=["Mapping", "Snapshot", "Compare"])
 
     social_gdf_2023 = load_2023_social()
     tidy_2023 = rename_and_merge_census_cols(social_gdf_2023)
 
     with mapping:
-        st.subheader("Mapping")
+        mapping_tab(data=tidy_2023)
         
-        # Select the combination of vars we're interested in
-        filtered_2023 = filter_dataframe(tidy_2023, filter_columns=["Category", "Subcategory", "Variable", "Measure"])
-        # Project geometry to latitude and longitude coordinates
-        filtered_2023 = filtered_2023.to_crs(epsg=4326)
-        
-        col1, _, _ = st.columns(3)
-        n_classes = col1.slider(label="Adjust the level of detail", value=10, min_value=5, max_value=15)
-        # Define the Jenk's colormap and apply it to the dataframe
-        jenks_cmap_dict = jenks_color_map(filtered_2023, n_classes, "Purples")
-        filtered_2023['fill_color'] = filtered_2023['color_groups'].astype(str).map(jenks_cmap_dict)
-        # Fill null values with a transparent color
-        filtered_2023['fill_color'] = filtered_2023['fill_color'].fillna("(0, 0, 0, 0)")
-
-        # Convert the geometry column to GeoJSON coordinates
-        filtered_2023["coordinates"] = filtered_2023.geometry.apply(
-            lambda geom: geom.__geo_interface__["coordinates"])
-            
-        # Chloropleth map layer
-        polygon_layer = pdk.Layer(
-            "PolygonLayer",
-            data=filtered_2023,
-            get_polygon="coordinates[0]",
-            get_fill_color="fill_color",
-            pickable=True,
-            auto_highlight=True,
-        )
-
-        # Set the map center and zoom level
-        view_state = pdk.ViewState(latitude=44.26, longitude=-72.57, min_zoom=6.5, zoom=7)
-
-        # Display the map to the page
-        st.pydeck_chart(pdk.Deck(
-            layers=[polygon_layer],
-            initial_view_state=view_state,
-            map_style="https://basemaps.cartocdn.com/gl/positron-gl-style/style.json",
-            tooltip={"text": "{Jurisdiction}: {Value}"}), height=550)
 
     # Social Snapshot
     with snapshot:
         st.subheader("Social Snapshot")
+
+    with compare:
+        compare_tab(data=tidy_2023)
+
             
 def show_social():
     # Display the page

--- a/test.txt
+++ b/test.txt
@@ -1,0 +1,14 @@
+__init__.py
+__pycache__
+analysis.py
+census.py
+color.py
+data_cleaning.py
+economic.py
+file_handling.py
+geospatial.py
+housing.py
+plot.py
+report.py
+wastewater.py
+zoning.py


### PR DESCRIPTION
- Created a new app_utils page, `st_sections.py ` to hold the large sections (eg, mapping tab, compare tab).  
- also generalized the data loading into a function in app_utils.census. Still have to cache it's return, but simpler. 

Goal: make stuff reusable and easier to maintain if needed.  Plus I just like trimmer, more modular code. 

Note: compare tab under process and current version not included.