### PR TITLE
Added the comparison tab across all census pages

### DIFF
--- a/app_utils/color.py
+++ b/app_utils/color.py
@@ -64,6 +64,7 @@ def render_colorbar(cmap, norm, vmin, vmax, cutoff, style, label="Scale"):
     cb.set_label(label)
 
     if style=="Holdout":
+        ticks = ticks[:-1]
         ticks = np.append(ticks, vmax)
     elif style == "Yellow":
         cb.set_label("Scale (Outliers in Yellow)")
@@ -71,13 +72,13 @@ def render_colorbar(cmap, norm, vmin, vmax, cutoff, style, label="Scale"):
         cb.set_label("Jenk's")
 
     cb.set_ticks(ticks)
-    cb.set_ticklabels([f"{t:.2g}" for t in ticks])
+    cb.set_ticklabels([f"{t:.0f}" for t in ticks])
 
     buf = io.BytesIO()
     plt.savefig(buf, format="png", bbox_inches='tight')
     plt.close(fig)
     
-    st.image(buf, width=450)
+    st.image(buf, use_container_width=True)
 
 
 def map_outlier_yellow(x, cmap, norm, cutoff):

--- a/pages/6_Housing.py
+++ b/pages/6_Housing.py
@@ -51,9 +51,10 @@ def census_housing_page():
     statewide_avg_val_df = (med_val_df.groupby("year", as_index=False)["estimate"].mean())
     statewide_avg_smoc_df = (med_smoc_df.groupby(["year", "variable"], as_index=False)["estimate"].mean())
 
+    # st.write(housing_gdf_2023.columns) debug
     ##  The map section ## 
     with mapping:
-        mapping_tab(tidy_2023)
+        mapping_tab(tidy_2023, )
     
     # Housing Snapshot
     with snapshot:
@@ -115,10 +116,13 @@ def census_housing_page():
                         filtered_gdf_2013, filtered_gdf_2023, housing_gdf_2023, 
                         filtered_med_val_df, filtered_med_smoc_df, 
                         statewide_avg_val_df, statewide_avg_smoc_df, compare_to)
-
-
+        
     with compare:
-        compare_tab(data=tidy_2023)
+        data_dict = {
+            "Housing 2023" : tidy_2023,
+            "Housing 2013" : rename_and_merge_census_cols(housing_gdf_2013)
+        }
+        compare_tab(data_dict)
         
 def show_housing():
     # Display the page

--- a/pages/7_Economics.py
+++ b/pages/7_Economics.py
@@ -78,7 +78,10 @@ def census_economics_page():
         economic_snapshot(county, jurisdiction, filtered_gdf_2023)
 
     with compare:
-        compare_tab(data=tidy_2023)
+        data_dict = {
+            "Economics 2023" : tidy_2023,
+        }
+        compare_tab(data_dict)
             
 def show_economics():
     # Display the page

--- a/pages/8_Demographics.py
+++ b/pages/8_Demographics.py
@@ -35,7 +35,10 @@ def render_demographics():
         st.subheader("Demographic Snapshot")
 
     with compare:
-        compare_tab(data=tidy_2023)           
+        data_dict = {
+            "Demographics 2023" : tidy_2023,
+        }
+        compare_tab(data_dict)   
 
 if __name__ == "__main__":
     render_demographics()

--- a/pages/9_Social.py
+++ b/pages/9_Social.py
@@ -35,7 +35,10 @@ def render_social():
         st.subheader("Social Snapshot")
 
     with compare:
-        compare_tab(data=tidy_2023)
+        data_dict = {
+            "Social 2023" : tidy_2023,
+        }
+        compare_tab(data_dict)
 
             
 def show_social():


### PR DESCRIPTION
Across all census pages, added a comparison tab that lets user: 

- select dataset, county, and town to compare
- select # of variables to compare
- select exact variables using cascading filtering 
- select which plots to show (can include an exportable print of the data, too).

Current plots are just barplots. 

Fixed integration with some other areas as had to refactor filter_dataframe a bit. 