### PR TITLE
Added dark theme support to the mapping tab

### DIFF
--- a/app_utils/census_sections.py
+++ b/app_utils/census_sections.py
@@ -54,6 +54,7 @@ def process_census_data(gdf, selected_values):
         lambda geom: geom.__geo_interface__["coordinates"]) 
     return gdf
 
+
 def add_census_tooltip(gdf, selected_values):
     ## hardcode a string to callout the variable we're mapping
     tooltip_fmt = f"{selected_values['Variable']} {selected_values['Measure']}".upper() 
@@ -62,17 +63,16 @@ def add_census_tooltip(gdf, selected_values):
         tooltip_fmt : "Value"
     })
 
+
 def mapping_tab(data): 
     st.subheader("Mapping")
-    theme_dict = st_theme(key="theme_mapping")
-    if theme_dict is not None:
-        theme = theme_dict["base"]
-    else:
-        theme = "light"  # or your fallback default
-    map_style = "dark" if theme == "dark" else "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json"
-    # Project meaningful columns to lat/long
-    filtered_2023, selected_value = filter_dataframe(data, filter_columns=["Category", "Subcategory", "Variable", "Measure"], key_prefix="mapping_filter")
-    filtered_2023.to_crs(epsg=4326)
+    
+    ## filter down to column to map
+    filtered_2023, selected_values = filter_dataframe(
+        data, 
+        filter_columns=["Category", "Subcategory", "Variable", "Measure"], 
+        key_prefix="mapping_filter_2023")
+    filtered_2023 = process_census_data(filtered_2023, selected_values)
  
     # Normalize the housing variable for monochromatic chloropleth coloring
     vmin, vmax, cutoff  = get_colornorm_stats(filtered_2023, 5)
@@ -100,9 +100,7 @@ def mapping_tab(data):
         render_colorbar(cmap=cmap, norm=norm, vmin=vmin, vmax=vmax, cutoff=cutoff, style=style)
     
     elif style == "Jenk's Natural Breaks":
-        # Option Two: Jenk's Natural Breaks Algorithm
-        # Using a slider, adjust the number of "groups" in the data
-        col1, _, _ = st.columns(3)
+        # Option Three: Jenk's Natural Breaks Algorithm
         n_classes=10
         # n_classes = col1.slider(label="Adjust the level of detail", value=10, min_value=5, max_value=15)
         # Define the Jenk's colormap and apply it to the dataframe
@@ -111,42 +109,12 @@ def mapping_tab(data):
         # Fill null values with a transparent color
         filtered_2023['fill_color'] = filtered_2023['fill_color'].fillna("(0, 0, 0, 0)")
 
-    # Convert the geometry column to GeoJSON coordinates
-    filtered_2023["coordinates"] = filtered_2023.geometry.apply(
-        lambda geom: geom.__geo_interface__["coordinates"]) 
-
-    # Chloropleth map layer
-    polygon_layer = pdk.Layer(
-        "PolygonLayer",
-        data=filtered_2023,
-        get_polygon="coordinates[0]",
-        get_fill_color="fill_color",
-        pickable=True,
-        auto_highlight=True)
-
-    # Set the map center and zoom settings
-    view_state = pdk.ViewState(latitude=44.26, longitude=-72.57, min_zoom=6.5, zoom=7)
-
-    # Display the map to the page
-    st.pydeck_chart(pdk.Deck(
-        layers=[polygon_layer],
-        initial_view_state=view_state,
-        map_style=map_style,
-        tooltip={"text": "{Jurisdiction}: {Value}"}), height=550)
-    
-    ## filter down to column to map
-    filtered_2023, selected_values = filter_dataframe(
-        data, 
-        filter_columns=["Category", "Subcategory", "Variable", "Measure"], 
-        key_prefix="mapping_filter")
-    filtered_2023 = process_census_data(filtered_2023, selected_values)
-
     # generate and display map
     map = map_gdf_single_layer(
         gdf=filtered_2023,
         view_state=pdk.ViewState(latitude=44.26, longitude=-72.57, min_zoom=6.5, zoom=7)
     )
-    st.pydeck_chart(map)
+    st.pydeck_chart(map, height=550)
 
 
 def select_dataset(col, data_dict, label_prefix):

--- a/app_utils/mapping.py
+++ b/app_utils/mapping.py
@@ -2,6 +2,7 @@
 import pydeck as pdk
 import json
 import geopandas as gpd
+import streamlit as st
 
 
 def build_layer(geojson, name="GeoJsonLayer"):
@@ -22,10 +23,27 @@ def build_layer(geojson, name="GeoJsonLayer"):
 
     return layer
 
+
+def pydeck_basemap_theme(key):
+    from streamlit_theme import st_theme
+
+    theme_dict = st_theme(key=f"{key}")
+    if theme_dict is not None:
+        theme = theme_dict["base"]
+    else:
+        theme = "light"
+    
+    map_style = "dark" if theme == "dark" else "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json"
+
+    return map_style
+
+
+
 def map_gdf_single_layer(gdf, view_state=None):
     """
     Function to convert gdf into geojson and then map it with tooltip. 
     """
+
     geojson = json.loads(gdf.to_json())
 
     ## create the layer
@@ -38,11 +56,12 @@ def map_gdf_single_layer(gdf, view_state=None):
         center_lat = (bounds[1] + bounds[3]) / 2
         view_state = pdk.ViewState(latitude=center_lat, longitude=center_lon, min_zoom=6.5, zoom=10)
 
-    tooltip = {"html" : "{tooltip}"}
 
+    tooltip = {"html" : "{tooltip}"}
+    map_style = pydeck_basemap_theme(key="theme_mapping")
     # return the map with layer
     return pdk.Deck(layers=[layer], initial_view_state=view_state, tooltip=tooltip,
-        map_style="https://basemaps.cartocdn.com/gl/positron-gl-style/style.json")
+        map_style=map_style)
 
 def add_tooltip_from_dict(gdf, label_to_col):
     """


### PR DESCRIPTION
Using a new function `pydeck_basemap_theme(key) function within the mapping tab, we are now able to check the current dark/light theme setting and adjust the pydeck basemap accordingly